### PR TITLE
Clean up leftover SkillList and demo.ts changes

### DIFF
--- a/src/components/SkillList.tsx
+++ b/src/components/SkillList.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Box, Text, useInput } from "ink";
 import { scanSkills, getSkillContent, editSkill } from "../lib/skills.js";
+import { useScrollable } from "../hooks/useScrollable.js";
 import type { Skill } from "../lib/skills.js";
 
 interface Props {
@@ -11,7 +12,6 @@ export default function SkillList({ onExit }: Props) {
   const [skills, setSkills] = useState<Skill[]>([]);
   const [cursor, setCursor] = useState(0);
   const [preview, setPreview] = useState<string[] | null>(null);
-  const [previewScroll, setPreviewScroll] = useState(0);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -24,36 +24,17 @@ export default function SkillList({ onExit }: Props) {
   const termHeight = process.stdout.rows || 24;
   const maxVisible = termHeight - 7;
 
+  const closePreview = useCallback(() => setPreview(null), []);
+
+  const { scroll: previewScroll, scrollPct } = useScrollable({
+    totalLines: preview?.length ?? 0,
+    maxVisible,
+    onClose: closePreview,
+    active: preview !== null,
+  });
+
   useInput((input, key) => {
-    if (preview) {
-      if (key.escape || input === "p" || input === "q") {
-        setPreview(null);
-        setPreviewScroll(0);
-      }
-      if (key.upArrow || input === "k") {
-        setPreviewScroll((s) => Math.max(0, s - 1));
-      }
-      if (key.downArrow || input === "j") {
-        setPreviewScroll((s) =>
-          Math.min(Math.max(0, preview.length - maxVisible), s + 1),
-        );
-      }
-      if (key.pageUp || input === "u") {
-        setPreviewScroll((s) => Math.max(0, s - maxVisible));
-      }
-      if (key.pageDown || input === "d") {
-        setPreviewScroll((s) =>
-          Math.min(Math.max(0, preview.length - maxVisible), s + maxVisible),
-        );
-      }
-      if (input === "g") {
-        setPreviewScroll(0);
-      }
-      if (input === "G") {
-        setPreviewScroll(Math.max(0, preview.length - maxVisible));
-      }
-      return;
-    }
+    if (preview) return;
 
     if (key.upArrow || input === "k") {
       setCursor((c) => Math.max(0, c - 1));
@@ -64,7 +45,6 @@ export default function SkillList({ onExit }: Props) {
     if (input === "p" && skills[cursor]) {
       getSkillContent(skills[cursor]).then((content) => {
         setPreview(content.split("\n"));
-        setPreviewScroll(0);
       });
     }
     if (input === "e" && skills[cursor]) {
@@ -87,12 +67,6 @@ export default function SkillList({ onExit }: Props) {
 
   if (preview) {
     const visible = preview.slice(previewScroll, previewScroll + maxVisible);
-    const scrollPct =
-      preview.length <= maxVisible
-        ? 100
-        : Math.round(
-            (previewScroll / (preview.length - maxVisible)) * 100,
-          );
 
     return (
       <Box flexDirection="column">

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -1,3 +1,4 @@
+import { groupByProject } from "./scanner.js";
 import type { Session, ProjectSummary, PreviewMessage } from "./scanner.js";
 
 const now = Date.now();
@@ -87,13 +88,7 @@ export const demoSessions: Session[] = [
   },
 ];
 
-export const demoProjects: ProjectSummary[] = [
-  { name: "my-saas", path: "/Users/demo/projects/my-saas", sessionCount: 3, lastActive: hours(0.5) },
-  { name: "blog", path: "/Users/demo/projects/blog", sessionCount: 2, lastActive: hours(8) },
-  { name: "api-server", path: "/Users/demo/projects/api-server", sessionCount: 2, lastActive: days(1) },
-  { name: "dotfiles", path: "/Users/demo/.dotfiles", sessionCount: 2, lastActive: days(1) },
-  { name: "infra", path: "/Users/demo/projects/infra", sessionCount: 1, lastActive: days(3) },
-];
+export const demoProjects: ProjectSummary[] = groupByProject(demoSessions);
 
 export const demoBookmarkedIds = new Set<string>();
 


### PR DESCRIPTION
## Summary
- SkillList.tsx: useScrollable 훅으로 리팩토링 (PR #6에서 누락)
- demo.ts: groupByProject 함수 사용으로 중복 데이터 제거

## Test plan
- [ ] `npm run build` 통과 확인
- [ ] `--demo` 모드 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)