### PR TITLE
Fix pre-push hook tag detection

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,7 +1,15 @@
 branch="$(git rev-parse --abbrev-ref HEAD)"
 
-# Allow tag-only pushes (no branch ref)
-if [ "$branch" = "HEAD" ]; then
+# Read pushed refs from stdin to detect tag-only pushes
+tags_only=true
+while read local_ref local_oid remote_ref remote_oid; do
+  case "$remote_ref" in
+    refs/tags/*) ;;
+    *) tags_only=false ;;
+  esac
+done
+
+if [ "$tags_only" = true ]; then
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- pre-push 훅이 `git push --tags`도 차단하던 버그 수정
- stdin의 ref를 파싱해서 태그만 push하는 경우 허용

## Test plan
- [ ] `git push --tags` 정상 통과
- [ ] `git push` on main → 차단

🤖 Generated with [Claude Code](https://claude.com/claude-code)