### PR TITLE
Fix Windows compatibility, add cross-platform CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npm run build

--- a/src/lib/bookmarks.ts
+++ b/src/lib/bookmarks.ts
@@ -1,5 +1,4 @@
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
-import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
@@ -31,7 +30,7 @@ function load(): BookmarkData {
 function save(data: BookmarkData): void {
   const dir = join(homedir(), ".config", "claudash");
   try {
-    execSync(`mkdir -p "${dir}"`);
+    mkdirSync(dir, { recursive: true });
     writeFileSync(BOOKMARKS_PATH, JSON.stringify(data, null, 2));
   } catch {
     // ignore

--- a/src/lib/launcher.ts
+++ b/src/lib/launcher.ts
@@ -1,5 +1,5 @@
 import { execSync, spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
@@ -33,7 +33,7 @@ function detectMode(): LaunchMode {
 function saveConfig(config: Config): void {
   const dir = join(homedir(), ".config", "claudash");
   try {
-    execSync(`mkdir -p "${dir}"`);
+    mkdirSync(dir, { recursive: true });
     writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
   } catch {
     // ignore


### PR DESCRIPTION
## Summary
- `execSync('mkdir -p')` → `fs.mkdirSync({ recursive: true })` (launcher.ts, bookmarks.ts)
- bookmarks.ts에서 불필요한 `execSync` import 제거
- CI 워크플로우 추가: Ubuntu, Windows, macOS 3개 OS에서 빌드 체크

Closes #4

## Test plan
- [ ] CI에서 Windows 빌드 통과 확인
- [ ] CI에서 macOS/Linux 빌드 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)