### PR TITLE
Add resume dive options menu

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -12,7 +12,7 @@ import {
   searchSessionContent,
   deleteSession,
 } from "./lib/scanner.js";
-import { resumeSession } from "./lib/launcher.js";
+import { resumeSession, type ResumeMode } from "./lib/launcher.js";
 import { toggleBookmark, getBookmarkedIds } from "./lib/bookmarks.js";
 import { getFooterText } from "./lib/keybindings.js";
 import {
@@ -53,6 +53,9 @@ export default function App({ version, updateInfo, demo }: AppProps) {
   const [showHelp, setShowHelp] = useState(false);
   const [sessionCursor, setSessionCursor] = useState(0);
   const [launchingSession, setLaunchingSession] = useState<Session | null>(null);
+  const [launchMode, setLaunchMode] = useState<ResumeMode>("just-dive");
+  const [showResumeMenu, setShowResumeMenu] = useState(false);
+  const [resumeMenuCursor, setResumeMenuCursor] = useState(0);
   const [animFrame, setAnimFrame] = useState(0);
   const [sortOrder, setSortOrder] = useState<SortOrder>("recent");
 
@@ -139,7 +142,35 @@ export default function App({ version, updateInfo, demo }: AppProps) {
 
   const currentViewSessions = view === "bookmarks" ? bookmarkedSessions : filteredSessions;
 
+  const resumeOptions: { mode: ResumeMode; label: string; desc: string }[] = [
+    { mode: "just-dive", label: "Just dive", desc: "--resume" },
+    { mode: "yolo-dive", label: "Yolo dive", desc: "--dangerously-skip-permissions" },
+    { mode: "fork-dive", label: "Fork & dive", desc: "--fork-session" },
+  ];
+
   useInput((input, key) => {
+    if (showResumeMenu) {
+      if (key.escape) {
+        setShowResumeMenu(false);
+        return;
+      }
+      if (key.upArrow || input === "k") {
+        setResumeMenuCursor((c) => Math.max(0, c - 1));
+        return;
+      }
+      if (key.downArrow || input === "j") {
+        setResumeMenuCursor((c) => Math.min(resumeOptions.length - 1, c + 1));
+        return;
+      }
+      if (key.return && selectedSession) {
+        setLaunchMode(resumeOptions[resumeMenuCursor].mode);
+        setShowResumeMenu(false);
+        setLaunchingSession(selectedSession);
+        return;
+      }
+      return;
+    }
+
     if (searchMode) {
       if (key.escape) {
         setSearchMode(false);
@@ -306,7 +337,7 @@ export default function App({ version, updateInfo, demo }: AppProps) {
           process.stdout.write(`  \x1b[2mClaude is thinking...\x1b[0m\n`);
           setTimeout(() => process.exit(0), 3000);
         } else {
-          resumeSession(launchingSession.id, launchingSession.projectPath);
+          resumeSession(launchingSession.id, launchingSession.projectPath, launchMode);
         }
       }, 100);
     }, 500);
@@ -314,8 +345,10 @@ export default function App({ version, updateInfo, demo }: AppProps) {
   }, [launchingSession]);
 
   const handleSelect = (session: Session) => {
-    if (!launchingSession) {
-      setLaunchingSession(session);
+    if (!launchingSession && !showResumeMenu) {
+      setSelectedSession(session);
+      setShowResumeMenu(true);
+      setResumeMenuCursor(0);
     }
   };
 
@@ -358,6 +391,33 @@ export default function App({ version, updateInfo, demo }: AppProps) {
 
   if (showHelp) {
     return <Help onClose={() => setShowHelp(false)} />;
+  }
+
+  if (showResumeMenu && selectedSession) {
+    return (
+      <Box flexDirection="column" paddingTop={1}>
+        <Box>
+          <Text bold color="cyan">Dive options</Text>
+          <Text dimColor>  {selectedSession.project} {selectedSession.id.slice(0, 8)}</Text>
+        </Box>
+        <Box marginTop={1} flexDirection="column">
+          {resumeOptions.map((opt, i) => (
+            <Box key={opt.mode}>
+              <Text color={i === resumeMenuCursor ? "cyan" : "gray"} bold={i === resumeMenuCursor}>
+                {i === resumeMenuCursor ? " ▶ " : "   "}
+              </Text>
+              <Text color={i === resumeMenuCursor ? "white" : "gray"} bold={i === resumeMenuCursor}>
+                {opt.label}
+              </Text>
+              <Text dimColor>  ({opt.desc})</Text>
+            </Box>
+          ))}
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>[j/k] select  [Enter] confirm  [Esc] cancel</Text>
+        </Box>
+      </Box>
+    );
   }
 
   if (launchingSession) {

--- a/src/lib/launcher.ts
+++ b/src/lib/launcher.ts
@@ -87,17 +87,30 @@ function launchTerminalApp(sessionId: string, projectPath: string): void {
   }
 }
 
-function launchInline(sessionId: string, projectPath: string): void {
-  process.chdir(projectPath);
-  spawnSync("claude", ["--resume", sessionId], { stdio: "inherit" });
+type ResumeMode = "just-dive" | "yolo-dive" | "fork-dive";
+
+function buildArgs(sessionId: string, mode: ResumeMode): string[] {
+  const args = ["--resume", sessionId];
+  if (mode === "yolo-dive") {
+    args.push("--dangerously-skip-permissions");
+  }
+  if (mode === "fork-dive") {
+    args.push("--fork-session");
+  }
+  return args;
 }
 
-export function resumeSession(sessionId: string, projectPath: string): void {
+function launchInline(sessionId: string, projectPath: string, mode: ResumeMode): void {
+  process.chdir(projectPath);
+  spawnSync("claude", buildArgs(sessionId, mode), { stdio: "inherit" });
+}
+
+export function resumeSession(sessionId: string, projectPath: string, mode: ResumeMode = "just-dive"): void {
   const config = loadConfig();
 
   switch (config.launchMode) {
     case "inline":
-      launchInline(sessionId, projectPath);
+      launchInline(sessionId, projectPath, mode);
       break;
     case "tmux":
       launchTmux(sessionId, projectPath);
@@ -109,12 +122,14 @@ export function resumeSession(sessionId: string, projectPath: string): void {
       launchTerminalApp(sessionId, projectPath);
       break;
     case "print":
-    default:
+    default: {
+      const args = buildArgs(sessionId, mode).join(" ");
       console.log(
-        `\n  cd "${projectPath}" && claude --resume "${sessionId}"\n`,
+        `\n  cd "${projectPath}" && claude ${args}\n`,
       );
       break;
+    }
   }
 }
 
-export { type LaunchMode, type Config, CONFIG_PATH, loadConfig, saveConfig };
+export { type LaunchMode, type ResumeMode, type Config, CONFIG_PATH, loadConfig, saveConfig };


### PR DESCRIPTION
## Summary
- Enter 시 resume 옵션 메뉴 표시
  - **Just dive** (--resume) — 기본 resume
  - **Yolo dive** (--dangerously-skip-permissions) — 권한 체크 스킵
  - **Fork & dive** (--fork-session) — 원본 유지하고 새 세션 분기
- j/k로 선택, Enter로 확정, Esc로 취소
- launcher.ts에 ResumeMode 타입 추가, 모드별 CLI 인자 빌드

## Test plan
- [ ] Sessions에서 Enter → 옵션 메뉴 표시
- [ ] Preview에서 Enter → 옵션 메뉴 표시
- [ ] 각 옵션 선택 후 올바른 CLI 인자로 resume
- [ ] Esc로 메뉴 취소 후 세션 목록 복귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)