### PR TITLE
Fix path decoding for dashed directories and worktree resume

### DIFF
--- a/src/lib/launcher.ts
+++ b/src/lib/launcher.ts
@@ -100,8 +100,30 @@ function buildArgs(sessionId: string, mode: ResumeMode): string[] {
   return args;
 }
 
+function resolveProjectPath(projectPath: string): string {
+  if (existsSync(projectPath)) return projectPath;
+
+  // Worktree path may be deleted — try to find the main repo
+  // Worktree paths typically look like /repo/.worktrees/name or /tmp/cc-worktree-xxx
+  const parts = projectPath.split("/");
+  const wtIdx = parts.findIndex((p) => p === ".worktrees" || p.startsWith("cc-worktree"));
+  if (wtIdx > 0) {
+    const mainRepo = parts.slice(0, wtIdx).join("/");
+    if (existsSync(mainRepo)) return mainRepo;
+  }
+
+  return projectPath;
+}
+
 function launchInline(sessionId: string, projectPath: string, mode: ResumeMode): void {
-  process.chdir(projectPath);
+  const resolved = resolveProjectPath(projectPath);
+  try {
+    process.chdir(resolved);
+  } catch {
+    console.error(`\n  Directory not found: ${projectPath}`);
+    console.error(`  The worktree may have been deleted.\n`);
+    return;
+  }
   spawnSync("claude", buildArgs(sessionId, mode), { stdio: "inherit" });
 }
 

--- a/src/lib/scanner.ts
+++ b/src/lib/scanner.ts
@@ -1,4 +1,5 @@
 import { readdir, readFile, stat, unlink, rm } from "node:fs/promises";
+import { statSync } from "node:fs";
 import { join, basename } from "node:path";
 import { homedir } from "node:os";
 
@@ -22,7 +23,38 @@ const CLAUDE_DIR = join(homedir(), ".claude");
 const PROJECTS_DIR = join(CLAUDE_DIR, "projects");
 
 function decodeProjectPath(encoded: string): string {
-  return encoded.replace(/-/g, "/");
+  // Claude Code encodes paths by replacing / with -
+  // Problem: directory names can contain dashes (e.g. "my-project")
+  // Solution: walk the filesystem to find the real path
+  const parts = encoded.replace(/^-/, "").split("-");
+  let resolved = "/";
+  let i = 0;
+
+  while (i < parts.length) {
+    // Try progressively longer segments joined with dashes
+    let found = false;
+    for (let j = parts.length; j > i; j--) {
+      const candidate = parts.slice(i, j).join("-");
+      const testPath = join(resolved, candidate);
+      try {
+        const s = statSync(testPath);
+        if (s.isDirectory()) {
+          resolved = testPath;
+          i = j;
+          found = true;
+          break;
+        }
+      } catch {
+        // not found, try shorter
+      }
+    }
+    if (!found) {
+      // Fallback: treat remaining parts as slash-separated
+      resolved = join(resolved, ...parts.slice(i));
+      break;
+    }
+  }
+  return resolved;
 }
 
 function projectDisplayName(encoded: string): string {


### PR DESCRIPTION
## Summary
- 디렉토리 이름에 `-`가 포함된 경우 경로 디코딩 오류 수정
  - 기존: 모든 `-`를 `/`로 변환 → `myproject.com_fix-www` → `myproject.com_fix/www` (잘못됨)
  - 수정: 파일시스템을 실제로 확인하면서 경로 복원
- 삭제된 worktree 경로로 resume 시 크래시 대신 에러 메시지 표시

Fixes #29

## Test plan
- [ ] 디렉토리명에 `-`가 있는 프로젝트 세션 정상 표시
- [ ] 삭제된 worktree 세션 resume 시 크래시 없음
- [ ] 기존 프로젝트 경로 디코딩 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)