### PR TITLE
Fix preview not showing content

### DIFF
--- a/src/lib/scanner.ts
+++ b/src/lib/scanner.ts
@@ -110,7 +110,7 @@ export interface PreviewMessage {
 
 export async function getSessionPreview(
   sessionId: string,
-  project: string,
+  _project: string,
 ): Promise<PreviewMessage[]> {
   const messages: PreviewMessage[] = [];
 
@@ -121,8 +121,8 @@ export async function getSessionPreview(
     return [];
   }
 
+  // Search all project dirs for the session file by ID
   for (const projDir of projectDirs) {
-    if (projectDisplayName(projDir) !== project) continue;
     const filePath = join(PROJECTS_DIR, projDir, `${sessionId}.jsonl`);
     try {
       const content = await readFile(filePath, "utf-8");
@@ -141,8 +141,9 @@ export async function getSessionPreview(
           continue;
         }
       }
+      if (messages.length > 0) return messages;
     } catch {
-      return [];
+      continue;
     }
   }
   return messages;


### PR DESCRIPTION
## Summary
cwd 리팩토링 후 `getSessionPreview`가 `projectDisplayName(projDir)`로 매칭하는데,
`projectDisplayName`이 이제 실제 경로를 받도록 바뀌어서 매칭이 안 됐음.

세션 ID로 모든 프로젝트 디렉토리를 직접 탐색하도록 수정.

## Test plan
- [ ] `p`로 Preview 진입 시 대화 내용 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)