### PR TITLE
Fix deleteSession, add tool stats to Preview

### DIFF
--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { Box, Text } from "ink";
-import { getSessionPreview } from "../lib/scanner.js";
+import { getSessionPreview, type ToolStats } from "../lib/scanner.js";
 import { useScrollable } from "../hooks/useScrollable.js";
 import type { Session, PreviewMessage } from "../lib/scanner.js";
 
@@ -63,8 +63,44 @@ function buildDisplayLines(
   return lines;
 }
 
+function classifySession(stats: ToolStats): string {
+  const total = Object.values(stats).reduce((a, b) => a + b, 0);
+  if (total === 0) return "💬 Conversation";
+
+  const get = (name: string) => stats[name] || 0;
+  const edit = get("Edit") + get("Write");
+  const bash = get("Bash");
+  const read = get("Read") + get("Grep") + get("Glob");
+  const write = get("Write");
+  const agent = get("Agent");
+  const skill = get("Skill");
+  const notebook = get("NotebookEdit");
+  const web = get("WebFetch") + get("WebSearch");
+
+  const top3 = Object.entries(stats)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 3)
+    .map(([name, count]) => `${name}:${count}`)
+    .join(" ");
+
+  if (total < 5) return `💬 Conversation (${top3})`;
+  if (notebook > 0) return `📓 Notebook work (${top3})`;
+  if (web > 0) return `🌐 Web research (${top3})`;
+  if (skill > 0 && skill >= total * 0.3) return `⚡ Skill execution (${top3})`;
+  if (agent > 0 && agent >= total * 0.1) return `🤖 Agentic workflow (${top3})`;
+  if (write > get("Edit")) return `📝 File creation (${top3})`;
+  if (read > edit && read > bash) return `🔍 Code exploration (${top3})`;
+  if (edit > bash && edit > read) return `🔨 Code editing (${top3})`;
+  if (bash > edit && bash > read) return `🐛 Debugging / Building (${top3})`;
+  if (Math.abs(edit - bash) / Math.max(edit, bash, 1) < 0.2) return `🔄 Build & iterate (${top3})`;
+
+  return `🔧 Mixed (${top3})`;
+}
+
 export default function Preview({ session, onClose, onSelect, demoData, demoSubtitle }: Props) {
   const [messages, setMessages] = useState<PreviewMessage[]>([]);
+  const [toolStats, setToolStats] = useState<ToolStats>({});
+  const [model, setModel] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -75,7 +111,9 @@ export default function Preview({ session, onClose, onSelect, demoData, demoSubt
     }
     setLoading(true);
     getSessionPreview(session.id, session.project).then((result) => {
-      setMessages(result);
+      setMessages(result.messages);
+      setToolStats(result.toolStats);
+      setModel(result.model);
       setLoading(false);
     });
   }, [session.id, session.project, demoData]);
@@ -117,6 +155,12 @@ export default function Preview({ session, onClose, onSelect, demoData, demoSubt
         <Text dimColor> {session.id.slice(0, 8)}...</Text>
         <Text dimColor>
           {"  "}{messages.length} messages
+        </Text>
+        {model && <Text dimColor>{"  "}{model.replace("claude-", "")}</Text>}
+      </Box>
+      <Box>
+        <Text dimColor>
+          {classifySession(toolStats)}
         </Text>
       </Box>
 

--- a/src/lib/scanner.ts
+++ b/src/lib/scanner.ts
@@ -304,9 +304,7 @@ export async function deleteSession(session: Session): Promise<boolean> {
   let deleted = false;
 
   for (const projDir of projectDirs) {
-    if (projectDisplayName(projDir) !== session.project) continue;
-
-    // Delete .jsonl file
+    // Find session file by ID directly
     const jsonlPath = join(PROJECTS_DIR, projDir, `${session.id}.jsonl`);
     try {
       await unlink(jsonlPath);

--- a/src/lib/scanner.ts
+++ b/src/lib/scanner.ts
@@ -108,17 +108,29 @@ export interface PreviewMessage {
   text: string;
 }
 
+export interface ToolStats {
+  [toolName: string]: number;
+}
+
+export interface SessionPreview {
+  messages: PreviewMessage[];
+  toolStats: ToolStats;
+  model: string | null;
+}
+
 export async function getSessionPreview(
   sessionId: string,
   _project: string,
-): Promise<PreviewMessage[]> {
+): Promise<SessionPreview> {
   const messages: PreviewMessage[] = [];
+  const toolStats: ToolStats = {};
+  let model: string | null = null;
 
   let projectDirs: string[];
   try {
     projectDirs = await readdir(PROJECTS_DIR);
   } catch {
-    return [];
+    return { messages, toolStats, model };
   }
 
   // Search all project dirs for the session file by ID
@@ -136,17 +148,30 @@ export async function getSessionPreview(
           } else if (msg.type === "assistant" && msg.message?.content) {
             const text = extractText(msg.message.content).trim();
             if (text) messages.push({ role: "assistant", text });
+            // Collect tool usage
+            const content = msg.message.content;
+            if (Array.isArray(content)) {
+              for (const block of content) {
+                if (block.type === "tool_use" && block.name) {
+                  toolStats[block.name] = (toolStats[block.name] || 0) + 1;
+                }
+              }
+            }
+            // Collect model
+            if (!model && msg.message.model) {
+              model = msg.message.model;
+            }
           }
         } catch {
           continue;
         }
       }
-      if (messages.length > 0) return messages;
+      if (messages.length > 0) return { messages, toolStats, model };
     } catch {
       continue;
     }
   }
-  return messages;
+  return { messages, toolStats, model };
 }
 
 export async function searchSessionContent(


### PR DESCRIPTION
## Summary
- `deleteSession`에서 `projectDisplayName(projDir)` 매칭 제거 — 세션 ID로 직접 탐색
- Preview 헤더에 사용 모델 표시 (e.g. `opus-4-6`)
- Preview에 세션 분류 라벨 추가:
  - 🔨 Code editing / 🐛 Debugging / 🔍 Code exploration
  - 🤖 Agentic workflow / 📝 File creation / 📓 Notebook work
  - 🌐 Web research / ⚡ Skill execution / 🔄 Build & iterate
  - 💬 Conversation / 🔧 Mixed
- 상위 3개 도구 사용 횟수 함께 표시

## Test plan
- [ ] Preview에서 도구 통계 + 분류 라벨 표시 확인
- [ ] 세션 삭제(`d`) 정상 동작 확인
- [ ] 도구 사용 없는 세션에서 `💬 Conversation` 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)